### PR TITLE
Fix import error in CRA environment

### DIFF
--- a/lib/Map.js
+++ b/lib/Map.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import OLMap from 'ol/Map';
+import OLMap from 'ol/Map.js';
 import {Component, createElement, createRef, forwardRef} from 'react';
 import {any, func, node, object, oneOfType, shape, string} from 'prop-types';
 import {render, updateInstanceFromProps} from '../renderer/render.js';

--- a/renderer/render.js
+++ b/renderer/render.js
@@ -7,7 +7,10 @@ import ReactReconciler from 'react-reconciler';
 import Source from 'ol/source/Source.js';
 import View from 'ol/View.js';
 import {CONTROL, INTERACTION, LAYER, OVERLAY, SOURCE, VIEW} from '../config.js';
-import {ConcurrentRoot, DefaultEventPriority} from 'react-reconciler/constants';
+import {
+  ConcurrentRoot,
+  DefaultEventPriority,
+} from 'react-reconciler/constants.js';
 import {
   prepareControlUpdate,
   prepareInteractionUpdate,


### PR DESCRIPTION
Using @planet/maps in a CRA app was causing an import error since the package.json specifys `type: "module"` the loader wants this import to end in `.js`.