### PR TITLE
Add a contributing doc

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,70 @@
+# Contributing to @planet/maps
+
+Thanks for your interest in contributing to the @planet/maps project.
+
+## Ways to Contribute
+
+## Bug Reports
+
+If you've found a bug, please [open an issue](https://github.com/planetlabs/maps/issues) describing what you've found.  It is important that you include enough information for others reading the issue to be able to reproduce the problem. While it can take some time, if you can provide a [minimal reproducible example](https://en.wikipedia.org/wiki/Minimal_reproducible_example), it will increase the chances that someone else will be able to help solve the problem.
+
+## Feature Requests
+
+If you've got an idea for a new feature, please open an issue describing what you are thinking of. You should do this before writing any code or opening a pull request with your proposed changes. After discussion about your feature request on an issue, you can submit a pull request with your proposed changes. See the [Developer Certificate of Origin](#developer-certificate-of-origin) section below for details on adding a `Signed-off-by` line to your commit messages.
+
+## Documentation Improvements
+
+We welcome any suggested improvements you may have for the project's documentation. You can submit a pull request for a documentation change without opening an issue first (as with feature requests above). See the [Developer Certificate of Origin](#developer-certificate-of-origin) section below for details on adding a `Signed-off-by` line to your commit messages.
+
+## Developer Certificate of Origin
+
+@planet/maps is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE file](./LICENSE)). The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+
+We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
+
+The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](http://developercertificate.org/).
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+We require that every contribution to @planet/maps is signed with a Developer Certificate of Origin. Additionally, please use your real name. We do not accept anonymous contributors nor those utilizing pseudonyms.
+
+Each commit must include a DCO which looks like this
+
+```
+Signed-off-by: Jane Smith <jane.smith@email.com>
+```
+
+You may type this line on your own when writing your commit messages. However, if your `user.name` and `user.email` are set in your [git config](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup), you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of the commit message.
+
+For example, the following would add a sign-off line that acts as a DCO:
+
+```
+git commit -s -m 'My first commit'
+```


### PR DESCRIPTION
This adds a doc with details on making a contribution.  We're going to try out requiring signed-off commits as a [DCO](https://developercertificate.org/).