### PR TITLE
Add example for StaticImage

### DIFF
--- a/site/src/components/examples/StaticImage.jsx
+++ b/site/src/components/examples/StaticImage.jsx
@@ -1,26 +1,29 @@
-import Map from '../../../../lib/Map.js';
-import View from '../../../../lib/View.js';
 import Image from '../../../../lib/layer/Image.js';
 import ImageStatic from '../../../../lib/source/ImageStatic.js';
-import Projection from "ol/proj/Projection";
-import { getCenter } from 'ol/extent.js';
+import Map from '../../../../lib/Map.js';
+import Projection from 'ol/proj/Projection.js';
+import React from 'react';
+import View from '../../../../lib/View.js';
+import {getCenter} from 'ol/extent.js';
 
 const extent = [0, 0, 1024, 968];
 const projection = new Projection({
-  code: "xkcd-image",
-  units: "pixels",
+  code: 'xkcd-image',
+  units: 'pixels',
   extent,
 });
 
 function StaticImage() {
   return (
     <Map>
-      <View options={{ projection, center: getCenter(extent), zoom: 2, maxZoom: 8 }} />
+      <View
+        options={{projection, center: getCenter(extent), zoom: 2, maxZoom: 8}}
+      />
       <Image>
         <ImageStatic
           options={{
             attributions: '© <a href="http://xkcd.com/license.html">xkcd</a>',
-            url: "https://imgs.xkcd.com/comics/online_communities.png",
+            url: 'https://imgs.xkcd.com/comics/online_communities.png',
             projection,
             imageExtent: extent,
           }}

--- a/site/src/components/examples/StaticImage.jsx
+++ b/site/src/components/examples/StaticImage.jsx
@@ -1,0 +1,33 @@
+import Map from '../../../../lib/Map.js';
+import View from '../../../../lib/View.js';
+import Image from '../../../../lib/layer/Image.js';
+import ImageStatic from '../../../../lib/source/ImageStatic.js';
+import Projection from "ol/proj/Projection";
+import { getCenter } from 'ol/extent.js';
+
+const extent = [0, 0, 1024, 968];
+const projection = new Projection({
+  code: "xkcd-image",
+  units: "pixels",
+  extent,
+});
+
+function StaticImage() {
+  return (
+    <Map>
+      <View options={{ projection, center: getCenter(extent), zoom: 2, maxZoom: 8 }} />
+      <Image>
+        <ImageStatic
+          options={{
+            attributions: '© <a href="http://xkcd.com/license.html">xkcd</a>',
+            url: "https://imgs.xkcd.com/comics/online_communities.png",
+            projection,
+            imageExtent: extent,
+          }}
+        />
+      </Image>
+    </Map>
+  );
+}
+
+export default StaticImage;

--- a/site/src/content/examples/static-image.mdx
+++ b/site/src/content/examples/static-image.mdx
@@ -1,0 +1,11 @@
+---
+title: 'Static Image'
+level: 0
+description: |
+  This example uses a [static image](https://xkcd.com/256/) as a layer source.
+  The map view is configured with a custom projection that translates image coordinates directly into map coordinates.
+---
+
+import StaticImage from '../../components/examples/StaticImage.jsx';
+
+<StaticImage client:only="react" />


### PR DESCRIPTION
Hi @tschaub - thanks for your work on this project.

I was able to test these changes locally by booting up Astro via `npm start` and see that my example I added was working.

As there are currently no typings for this, I referenced both [your ol example](https://openlayers.org/en/latest/examples/static-image.html) as well as @crubier's [example](https://github.com/crubier/react-openlayers-fiber/blob/master/packages/website/pages/examples/openlayers/static-image.en-US.mdx) to try to get a better sense of how this might work.

I am unsure if this is the "right" way to display a static image in this declarative paradigm, so I'm open to any guidance here.

<img width="1285" alt="image" src="https://github.com/planetlabs/maps/assets/12259854/f2e37b2e-e52b-49ff-a9cd-b3a6f60493a7">
