### PR TITLE
Add peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,11 @@
         "vite": "^4.0.4",
         "vitest": "^0.34.1",
         "yargs-parser": "^21.1.1"
+      },
+      "peerDependencies": {
+        "ol": "*",
+        "ol-mapbox-style": "*",
+        "react": "*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   "dependencies": {
     "react-reconciler": "^0.29.0"
   },
+  "peerDependencies": {
+    "ol": "*",
+    "ol-mapbox-style": "*",
+    "react": "*"
+  },
   "devDependencies": {
     "@astrojs/mdx": "^1.1.0",
     "@astrojs/react": "^3.0.2",


### PR DESCRIPTION
This adds `react`, `ol`, `ol-mapbox-style` as peer dependencies.  These are intentionally very lenient to allow applications to specify what they require.

This may or may not make the situation with yarn better (see #253).