### PR TITLE
Include repository info in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "9.0.1",
   "description": "Declarative mapping components for React",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/planetlabs/maps.git"
+  },
   "scripts": {
     "pretest": "npm run lint",
     "test": "npm run test:rendering",


### PR DESCRIPTION
This adds a link to the repo from the https://www.npmjs.com/package/@planet/maps page.