### PR TITLE
Accept onChange-foo type props as an alternative to onChange:foo

### DIFF
--- a/lib/internal/render.js
+++ b/lib/internal/render.js
@@ -49,7 +49,7 @@ export function updateInstanceFromProps(instance, props, oldProps = {}) {
     if (listenerRegex.test(key)) {
       const listener = props[key];
       const type = key
-        .replace(listenerColonRegex, "onChange:")
+        .replace(listenerColonRegex, 'onChange:')
         .replace(listenerRegex, '$1')
         .toLowerCase();
       instance.on(type, listener);

--- a/lib/internal/render.js
+++ b/lib/internal/render.js
@@ -22,7 +22,7 @@ import {
 } from './update.js';
 
 const listenerRegex = /^on([A-Z].*)/;
-const listenerColonRegex = /_/g;
+const listenerColonRegex = /^onChange-/;
 
 function upperFirst(str) {
   return str[0].toUpperCase() + str.slice(1);
@@ -48,7 +48,7 @@ export function updateInstanceFromProps(instance, props, oldProps = {}) {
     }
     if (listenerRegex.test(key)) {
       const listener = props[key];
-      const type = key.replace(listenerRegex, '$1').toLowerCase().replace(listenerColonRegex, ":");
+      const type = key.replace(listenerColonRegex, "onChange:").replace(listenerRegex, '$1').toLowerCase();
       instance.on(type, listener);
       if (oldProps[key]) {
         instance.un(type, oldProps[key]);

--- a/lib/internal/render.js
+++ b/lib/internal/render.js
@@ -22,6 +22,7 @@ import {
 } from './update.js';
 
 const listenerRegex = /^on([A-Z].*)/;
+const listenerColonRegex = /_/g;
 
 function upperFirst(str) {
   return str[0].toUpperCase() + str.slice(1);
@@ -47,7 +48,7 @@ export function updateInstanceFromProps(instance, props, oldProps = {}) {
     }
     if (listenerRegex.test(key)) {
       const listener = props[key];
-      const type = key.replace(listenerRegex, '$1').toLowerCase();
+      const type = key.replace(listenerRegex, '$1').toLowerCase().replace(listenerColonRegex, ":");
       instance.on(type, listener);
       if (oldProps[key]) {
         instance.un(type, oldProps[key]);

--- a/lib/internal/render.js
+++ b/lib/internal/render.js
@@ -48,7 +48,10 @@ export function updateInstanceFromProps(instance, props, oldProps = {}) {
     }
     if (listenerRegex.test(key)) {
       const listener = props[key];
-      const type = key.replace(listenerColonRegex, "onChange:").replace(listenerRegex, '$1').toLowerCase();
+      const type = key
+        .replace(listenerColonRegex, "onChange:")
+        .replace(listenerRegex, '$1')
+        .toLowerCase();
       instance.on(type, listener);
       if (oldProps[key]) {
         instance.un(type, oldProps[key]);

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,7 +62,9 @@ function MyApp() {
       <li>
         Listeners for OpenLayers events can be added with
         <code>on</code> -prefixed props. For example, <code>onChange</code> will
-        be called for <code>change</code> events.
+        be called for <code>change</code> events. Colons in props can cause issues
+        with React, so we also expose props like <code>onChange_center</code> along 
+        with <code>onChange:center</code>.
       </li>
       <li>
         All other props can be updated if there is a corresponding

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -63,7 +63,7 @@ function MyApp() {
         Listeners for OpenLayers events can be added with
         <code>on</code> -prefixed props. For example, <code>onChange</code> will
         be called for <code>change</code> events. Colons in props can cause issues
-        with React, so we also expose props like <code>onChange_center</code> along 
+        with React, so we also expose props like <code>onChange-center</code> along 
         with <code>onChange:center</code>.
       </li>
       <li>

--- a/tests/lib/View.test.jsx
+++ b/tests/lib/View.test.jsx
@@ -73,4 +73,31 @@ describe('<View>', () => {
     const center = await onChangeCenter.called;
     expect(center).toEqual([10, 20]);
   });
+
+  it('accepts a change listener with onChange-center prop', async () => {
+    const onChangeCenter = callback(event => {
+      const view = event.target;
+      return view.getCenter();
+    });
+
+    let map;
+    render(
+      <div style={style}>
+        <Map ref={r => (map = r)}>
+          <View
+            center={[1, 2]}
+            zoom={3}
+            rotation={4}
+            onChange-center={onChangeCenter.handler}
+          />
+        </Map>
+      </div>,
+    );
+
+    const view = map.getView();
+    view.setCenter([10, 20]);
+
+    const center = await onChangeCenter.called;
+    expect(center).toEqual([10, 20]);
+  });
 });


### PR DESCRIPTION
Allow to to use the name `onChange_center` along with `onChange:center` in react props for listeners.

Also updated docs a bit.

Fixes https://github.com/planetlabs/maps/issues/533