### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
       - 'v*.*.*'
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 
 jobs:
@@ -31,8 +32,6 @@ jobs:
           npm run build:types
           cp package.json readme.md lib && cd lib
           npm publish --tag dev
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -53,5 +52,3 @@ jobs:
           npm run build:types
           cp package.json readme.md lib && cd lib
           npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
I've configured the repo to work with [trusted publishing on npm](https://docs.npmjs.com/trusted-publishers). This change removes the use of the token for publishing (this token has expired, so publishing to the dev tag has been failing).